### PR TITLE
US217728: Upgrade token lib to version 3.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <spring-security.version>4.2.0.RELEASE</spring-security.version>
         <titandb.version>1.1.0-SNAPSHOT</titandb.version>
         <openjpa.version>2.4.2</openjpa.version>
-        <uaa-token-lib.version>3.3.2</uaa-token-lib.version>
+        <uaa-token-lib.version>3.3.6</uaa-token-lib.version>
 
         <!-- Test Dependency Version -->
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
US217728: Release token lib version 3.3.5 - Path traversal fix and 3.3.6 - FastTokenService bean creation fix