### PR TITLE
US280243: Optimize policy evaluation for cached results.

### DIFF
--- a/service/src/main/java/org/eclipse/keti/acs/policy/evaluation/cache/AbstractPolicyEvaluationCache.java
+++ b/service/src/main/java/org/eclipse/keti/acs/policy/evaluation/cache/AbstractPolicyEvaluationCache.java
@@ -30,6 +30,10 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import org.codehaus.jackson.map.ObjectMapper;
+import org.eclipse.keti.acs.attribute.connector.management.AttributeConnectorService;
+import org.eclipse.keti.acs.privilege.management.dao.ResourceEntity;
+import org.eclipse.keti.acs.privilege.management.dao.SubjectEntity;
+import org.eclipse.keti.acs.rest.PolicyEvaluationResult;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Minutes;
@@ -37,11 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import org.eclipse.keti.acs.attribute.connector.management.AttributeConnectorService;
-import org.eclipse.keti.acs.privilege.management.dao.ResourceEntity;
-import org.eclipse.keti.acs.privilege.management.dao.SubjectEntity;
-import org.eclipse.keti.acs.rest.PolicyEvaluationResult;
 
 enum EntityType {
 
@@ -242,9 +241,7 @@ public abstract class AbstractPolicyEvaluationCache implements PolicyEvaluationC
         }
 
         Set<String> policySetIds = key.getPolicySetIds();
-        for (String policySetId : policySetIds) {
-            setPolicySetIfNotExists(zoneId, policySetId);
-        }
+        policySetIds.forEach(policySetId -> setPolicySetIfNotExists(zoneId, policySetId));
     }
 
     @Override
@@ -281,6 +278,8 @@ public abstract class AbstractPolicyEvaluationCache implements PolicyEvaluationC
     @Override
     public void resetForPolicySet(final String zoneId, final String policySetId) {
         resetForEntity(zoneId, policySetId, EntityType.POLICY_SET, AbstractPolicyEvaluationCache::policySetKey);
+        resetForEntity(zoneId, PolicyEvaluationRequestCacheKey.ANY_POLICY_SET_KEY, EntityType.POLICY_SET,
+                AbstractPolicyEvaluationCache::policySetKey);
     }
 
     private void setPolicySetIfNotExists(final String zoneId, final String policySetId) {

--- a/service/src/test/java/org/eclipse/keti/acs/policy/evaluation/cache/InMemoryPolicyEvaluationCacheTest.java
+++ b/service/src/test/java/org/eclipse/keti/acs/policy/evaluation/cache/InMemoryPolicyEvaluationCacheTest.java
@@ -26,13 +26,12 @@ import static org.testng.Assert.assertEquals;
 import java.util.Map;
 
 import org.codehaus.jackson.map.ObjectMapper;
-import org.joda.time.DateTime;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.Test;
-
 import org.eclipse.keti.acs.model.Effect;
 import org.eclipse.keti.acs.rest.PolicyEvaluationRequestV1;
 import org.eclipse.keti.acs.rest.PolicyEvaluationResult;
+import org.joda.time.DateTime;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
 
 public class InMemoryPolicyEvaluationCacheTest {
 
@@ -53,8 +52,8 @@ public class InMemoryPolicyEvaluationCacheTest {
         request.setAction(ACTION_GET);
         request.setSubjectIdentifier(AGENT_MULDER);
         request.setResourceIdentifier(XFILES_ID);
-        PolicyEvaluationRequestCacheKey key = new PolicyEvaluationRequestCacheKey.Builder().zoneId(ZONE_NAME)
-                .request(request).build();
+
+        PolicyEvaluationRequestCacheKey key = new PolicyEvaluationRequestCacheKey(request, ZONE_NAME);
 
         PolicyEvaluationResult result = new PolicyEvaluationResult(Effect.PERMIT);
         String value = OBJECT_MAPPER.writeValueAsString(result);

--- a/service/src/test/java/org/eclipse/keti/acs/service/policy/evaluation/PolicyEvaluationServiceTest.java
+++ b/service/src/test/java/org/eclipse/keti/acs/service/policy/evaluation/PolicyEvaluationServiceTest.java
@@ -206,14 +206,19 @@ public class PolicyEvaluationServiceTest extends AbstractTestNGSpringContextTest
             expectedExceptions = IllegalArgumentException.class)
     public void testFilterPolicySetsByPriorityForInvalidRequest(final List<PolicySet> allPolicySets,
             final LinkedHashSet<String> policySetsPriority) {
-        this.evaluationService.filterPolicySetsByPriority("subject1", "resource1", allPolicySets, policySetsPriority);
+
+        when(this.policyService.getAllPolicySets()).thenReturn(allPolicySets);
+        this.evaluationService.filterPolicySetsByPriority("subject1", "resource1", policySetsPriority);
     }
 
     @Test(dataProvider = "filterPolicySetsDataProvider")
     public void testFilterPolicySetsByPriority(final List<PolicySet> allPolicySets,
             final LinkedHashSet<String> policySetsPriority, final LinkedHashSet<PolicySet> expectedFilteredPolicySets) {
+
+        when(this.policyService.getAllPolicySets()).thenReturn(allPolicySets);
         LinkedHashSet<PolicySet> actualFilteredPolicySets = this.evaluationService
-                .filterPolicySetsByPriority("subject1", "resource1", allPolicySets, policySetsPriority);
+                .filterPolicySetsByPriority("subject1", "resource1", policySetsPriority);
+
         Assert.assertEquals(actualFilteredPolicySets, expectedFilteredPolicySets);
     }
 


### PR DESCRIPTION
- Remove loading of policy sets from the database for cached results.
- Remove TTL for evaluation decision cache.